### PR TITLE
Prevent race condition when creating `workdir`

### DIFF
--- a/SeisCL/SeisCL.py
+++ b/SeisCL/SeisCL.py
@@ -316,8 +316,10 @@ class SeisCL:
     @workdir.setter
     def workdir(self, workdir):
         self.__workdir = workdir
-        if not os.path.isdir(workdir):
+        try:
             os.mkdir(workdir)
+        except FileExistsError:
+            pass
 
     # When setting a file for the datalist, load the datalist from it
     @property


### PR DESCRIPTION
Checking if `workdir` exists and then creating it may fail with `FileExistsError` if another process is creating the directory at the same time. Instead, always try to create it and escape if it already exists.

Hope this proves helpful! 🚀