### PR TITLE
Populate FL so viscoelastic runs work through SeisCL.torch

### DIFF
--- a/SeisCL/tests/test_torch_binding.py
+++ b/SeisCL/tests/test_torch_binding.py
@@ -434,6 +434,63 @@ def _multishot_geometry(nshot, nrec=6):
             torch.tensor(rp, dtype=torch.float32))
 
 
+def _viscoelastic_params(tau=0.02):
+    p = _homogeneous_params()
+    nz, nx = N
+    p["taup"] = torch.full((nz * nx,), tau, dtype=torch.float32)
+    p["taus"] = torch.full((nz * nx,), tau, dtype=torch.float32)
+    return p
+
+
+def test_viscoelastic_requires_FL():
+    """cfg.L>0 needs cfg.FL, and honours its values.
+
+    Regression test for the original torch binding: Config exposed L but
+    nothing populated the "FL" constants array, so assign_modeling_case()'s
+    zero-filled allocation reached eta() (eta[l]=2*pi*FL[l]*dt=0) and the
+    M()/mu() transforms computed dt/eta[l] -> Inf. Every viscoelastic run
+    returned Inf/NaN silently, even with valid taup/taus.
+    """
+    src, src_pos, rec_pos = _simple_geometry()
+
+    def run(L, FL=None, tau=0.02):
+        cfg = _make_config()
+        cfg.L = L
+        if FL is not None:
+            cfg.FL = FL
+        params = _viscoelastic_params(tau) if L else _homogeneous_params()
+        return seiscl_forward(cfg, params, src, src_pos, rec_pos)["vx"]
+
+    # A missing or wrong-length FL must be a clear error, not silent NaN.
+    for L, FL in ((1, None), (2, [15.0])):
+        try:
+            run(L, FL)
+            raise AssertionError(f"L={L} FL={FL} should have been rejected")
+        except ValueError as exc:
+            assert "FL" in str(exc), str(exc)
+
+    vx_elastic = run(0)
+    vx_visco = run(1, [25.0])
+    assert torch.isfinite(vx_visco).all(), "viscoelastic output not finite"
+    assert (vx_visco != 0).any(), "viscoelastic output is all zero"
+
+    # Attenuation must actually do something: less energy than elastic.
+    e_el = float((vx_elastic ** 2).sum())
+    e_vi = float((vx_visco ** 2).sum())
+    assert e_vi < e_el, f"viscoelastic not attenuated: {e_vi:.4g} vs {e_el:.4g}"
+
+    # FL is part of the engine cache key: same L, different FL must rebuild
+    # rather than silently reuse the first build's relaxation times.
+    a = run(1, [10.0])
+    b = run(1, [60.0])
+    assert float((a - b).abs().max()) > 0, \
+        "different FL returned identical data -- stale cached build"
+    assert torch.equal(a, run(1, [10.0])), \
+        "same FL not reproducible on a cache hit"
+
+    print("Testing: torch_viscoelastic_requires_FL ....... passed")
+
+
 def test_multishot_gradient_both_checkpoint_policies():
     """Multi-shot gradients are right whether the checkpoint is RAM or a file.
 
@@ -504,4 +561,5 @@ if __name__ == "__main__":
         test_cache_eviction_correctness()
         test_checkpoint_survives_interleaved_forward()
         test_checkpoint_survives_cache_clear()
+        test_viscoelastic_requires_FL()
         test_multishot_gradient_both_checkpoint_policies()

--- a/SeisCL/torch/bindings.cpp
+++ b/SeisCL/torch/bindings.cpp
@@ -163,6 +163,7 @@ CacheKey make_cache_key(const Config &cfg, int allns, int allng,
     k.K_MAX_CPML = cfg.K_MAX_CPML;
     k.abpc = cfg.abpc;
     k.L = cfg.L;
+    k.FL = cfg.FL;
     k.f0 = cfg.f0;
     k.par_type = cfg.par_type;
     k.FP16 = cfg.FP16;
@@ -535,6 +536,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         .def_readwrite("K_MAX_CPML", &Config::K_MAX_CPML)
         .def_readwrite("abpc", &Config::abpc)
         .def_readwrite("L", &Config::L)
+        .def_readwrite("FL", &Config::FL)
         .def_readwrite("f0", &Config::f0)
         .def_readwrite("par_type", &Config::par_type)
         .def_readwrite("FP16", &Config::FP16)

--- a/SeisCL/torch/cache_key.h
+++ b/SeisCL/torch/cache_key.h
@@ -35,6 +35,11 @@ struct CacheKey {
     float K_MAX_CPML;
     float abpc;
     int L;
+    // Not just L: FL's values feed eta() during Init_cst(), which a cache
+    // hit skips entirely (engine_refresh_params re-runs Init_model_values
+    // only). Two runs differing solely in FL would otherwise silently share
+    // the first one's relaxation times.
+    std::vector<float> FL;
     float f0;
     int par_type;
     int FP16;
@@ -80,6 +85,7 @@ struct CacheKey {
                NAB == o.NAB && ABS_TYPE == o.ABS_TYPE && VPPML == o.VPPML &&
                FPML == o.FPML && NPOWER == o.NPOWER &&
                K_MAX_CPML == o.K_MAX_CPML && abpc == o.abpc && L == o.L &&
+               FL == o.FL &&
                f0 == o.f0 && par_type == o.par_type && FP16 == o.FP16 &&
                restype == o.restype && GRADSRCOUT == o.GRADSRCOUT &&
                HOUT == o.HOUT && BACK_PROP_TYPE == o.BACK_PROP_TYPE &&
@@ -115,6 +121,7 @@ struct CacheKeyHash {
         combine(h, k.K_MAX_CPML);
         combine(h, k.abpc);
         combine(h, k.L);
+        for (float f : k.FL) combine(h, f);
         combine(h, k.f0);
         combine(h, k.par_type);
         combine(h, k.FP16);

--- a/SeisCL/torch/config.h
+++ b/SeisCL/torch/config.h
@@ -31,6 +31,13 @@ struct Config {
     float abpc = 4.0f;
     int L = 0;
     float f0 = 15.0f;
+    // Center frequencies of the L attenuation mechanisms (SeisCL.py's FL,
+    // normally read from the csts file as "/FL"). Must have exactly L
+    // entries whenever L > 0: assign_modeling_case()'s eta() derives
+    // eta[l] = 2*pi*FL[l]*dt, and the M()/mu() transforms then compute
+    // dt/eta[l], so a zero-filled FL yields Inf/NaN model parameters
+    // rather than an error.
+    std::vector<float> FL;
     int par_type = 0;
     int FP16 = 0;
     int restype = 0;

--- a/SeisCL/torch/engine_handle.cpp
+++ b/SeisCL/torch/engine_handle.cpp
@@ -109,6 +109,17 @@ void apply_config(model &m, const Config &cfg, int gradout, int inputres) {
             "(boundary-storage gradient)");
     }
 
+    if (cfg.L > 0 && static_cast<int>(cfg.FL.size()) != cfg.L) {
+        // Caught here rather than at the memcpy below so the message names
+        // the real problem. Without it, a zero-filled FL propagates through
+        // eta() into dt/eta[l] and the run returns Inf/NaN seismograms with
+        // no diagnostic at all.
+        throw std::invalid_argument(
+            "cfg.L=" + std::to_string(cfg.L) + " requires cfg.FL to hold "
+            "exactly " + std::to_string(cfg.L) + " attenuation-mechanism "
+            "center frequencies (got " + std::to_string(cfg.FL.size()) + ")");
+    }
+
     m.GRADOUT = gradout;
     m.INPUTRES = inputres;
     m.VARSOUT = 1;
@@ -219,6 +230,20 @@ int engine_build(EngineHandle &h, const Config &cfg, int gradout, int inputres,
     // whatever assign_modeling_case already allocated.
     set_params(h.m, params);
     set_srcrec(h.m, src, src_pos, rec_pos, output_fields);
+
+    // FL is normally read from the csts file (read_hdf5.c, dataset "/FL");
+    // with no file, fill it here. assign_modeling_case() has allocated the
+    // array by now (append_cst(m,"FL","/FL",m->L,NULL)) and Init_cst() is
+    // what runs eta()'s transform over it, so this must sit between the
+    // two. Same shape as the geometry/parameter uploads just above.
+    if (!state && h.m.L > 0) {
+        constants *fl = get_cst(h.m.csts, h.m.ncsts, "FL");
+        if (!fl || fl->num_ele != h.m.L) {
+            throw std::runtime_error(
+                "FL constants array was not registered as expected");
+        }
+        std::memcpy(fl->gl_cst, cfg.FL.data(), sizeof(float) * h.m.L);
+    }
 
     if (!state) state = Init_cst(&h.m);
     if (!state) state = Init_data(&h.m);


### PR DESCRIPTION
## The bug

`Config` exposed `L` and copied it to `m.L`, but nothing ever filled the `"FL"` constants array (the `L` attenuation-mechanism center frequencies).

The HDF5 path reads it as dataset `/FL`. The binding has no file, so `assign_modeling_case()`'s zero-filled allocation went straight through:

- `eta()` derives `eta[l] = 2*pi*FL[l]*dt` → **0**
- the `M()`/`mu()` transforms then compute `dt/eta[l]` → **Inf**

Every `cfg.L > 0` call returned Inf/NaN seismograms **silently**, even with valid `taup`/`taus` supplied — so the viscoelastic support the binding advertises (`bindings.cpp`'s own header comment mentions `taup`/`taus` "when `cfg.L>0`") was unusable.

Pre-existing since the binding landed in #13, so it affects `devel` and every branch off it. Surfaced by Codex review on #14, but fixed here rather than there: #14 predates the `bindings.cpp` → `engine_handle.cpp` split, so fixing it on that branch would have conflicted with #16 later.

## The fix

- `Config.FL` (`std::vector<float>`), memcpy'd into the constants array **between `assign_modeling_case()` and `Init_cst()`** — the only window where the array exists but `eta()`'s transform has not yet run.
- A length mismatch against `cfg.L` raises up front, so the failure names its cause instead of surfacing as NaN much later.
- **`FL` is part of the engine cache key**, not just `L`. `Init_cst()` is skipped entirely on a cache hit (`engine_refresh_params` re-runs `Init_model_values` only), so without this, two runs differing solely in `FL` would silently share the first one's relaxation times.

This follows the same shape #16 uses for `gradfreqs`.

## Testing

New `test_viscoelastic_requires_FL` covers:

| Case | Expected |
|---|---|
| `L=1`, no `FL` | clear `ValueError`, not NaN |
| `L=2`, 1-entry `FL` | clear `ValueError` |
| `L=1`, valid `FL` | finite, nonzero |
| vs. elastic | actually attenuated (energy ratio 0.96) |
| same `L`, different `FL` | different data (cache key honoured) |
| same `FL` twice | bit-reproducible |

Full `test_torch_binding.py` suite: **13/13**, elastic paths bit-unchanged.

One unrelated flake seen once in five runs — `test_multishot_gradient_both_checkpoint_policies` at drift 0.0447 vs a 0.02 tolerance. That is the documented pre-existing multi-shot gradient non-reproducibility (`notes/torch-binding-performance.md`), not this change: it passed the other four runs, and this diff is a no-op for `L=0` (the `FL` memcpy is guarded, and an empty `FL` vector leaves both the hash and the equality comparison unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETEo49hAfPsW2XxRHFE59f